### PR TITLE
Some fixes for the schema and index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,26 @@
 <?php
-include_once(dirname(dirname(__FILE__)).DIRECTORY_SEPARATOR.'common.inc.php');
+require_once dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR .'common.inc.php';
 
-$space = new LocalSchemaUriSpace(dirname(__FILE__) . '/schema.rdf.xml', 'rdfxml');
+class PlacesUriSpace extends LocalSchemaUriSpace {
+
+  function __construct($filename, $file_format) {
+    parent::__construct($filename, $file_format, FALSE);
+  }
+
+  function resource_uri_to_request_uri($resource_uri) {
+    $resource_uri = preg_replace("~purl.org/ontology/places~","vocab.org/places/schema", $resource_uri);
+    return parent::resource_uri_to_request_uri($resource_uri);
+  }
+
+  function request_uri_to_resource_uri($request_uri) {
+    $request_uri = preg_replace("~vocab.org/places/schema~","purl.org/ontology/places", $request_uri);
+    return parent::request_uri_to_resource_uri($request_uri);
+  }
+
+}
+
+
+$space = new PlacesUriSpace(dirname(__FILE__) . '/schema.rdf.xml','rdfxml');
+$space->add_redirect('/places/', '/places/schema');
 $space->dispatch();
 ?>

--- a/schema.rdf.ttl
+++ b/schema.rdf.ttl
@@ -19,11 +19,11 @@
 ; rdfs:comment "The Places Ontology is a simple lightweight ontology for describing places of geographic interest."@en
 ; dcterms:description "The Places Ontology is a simple lightweight ontology for describing places of geographic interest."@en
 ; foaf:maker <http://purl.org/ontology/places/#tom>, <http://purl.org/ontology/places/#rob>, <http://purl.org/ontology/places/#michael>
-; vann:preferredNamespaceUri place:
+; vann:preferredNamespaceUri "http://purl.org/ontology/places#"
 ; vann:preferredNamespacePrefix "place"
 .
 
-<> a cc:Work
+<http://purl.org/ontology/places> a cc:Work
 ; cc:license <http://creativecommons.org/licenses/by/1.0/>
 ; dcterms:type <http://purl.org/dc/dcmitype/Text>
 .
@@ -450,51 +450,51 @@ place:latlong a rdfs:Datatype
 # Language Labels
 #####################################################################
 
-place:Plate rdfs:label "Plate"@en-gb,"Plate"@fr-fr,"Tafel"@de,"Placa"@es,"板"@zh .
-place:LandMass rdfs:label "Landmass"@en-gb,"La masse continentale"@fr-fr,"Landmasse"@de,"Masa de tierra"@es,"陆地"@zh .
-place:Island rdfs:label "Island"@en-gb,"Island"@fr-fr,"Island"@de,"Isla"@es,"岛"@zh .
-place:Continent rdfs:label "Continent"@en-gb,"Continent"@fr-fr,"Kontinent"@de,"Continente"@es,"大陆"@zh .
-place:Country rdfs:label "Country"@en-gb,"Pays"@fr-fr,"Land"@de,"País"@es,"国家"@zh .
-place:Region rdfs:label "Region"@en-gb,"Région"@fr-fr,"Region"@de,"Región"@es,"区"@zh .
-place:ArbitraryRegion rdfs:label "Arbitrary Region"@en-gb,"Région Arbitraire"@fr-fr,"Willkürliche Region"@de,"Arbitraria Región"@es,"任意区域"@zh .
-place:City rdfs:label "City"@en-gb,"City"@fr-fr,"City"@de,"Ciudad"@es,"市"@zh .
-place:Town rdfs:label "Town"@en-gb,"Ville"@fr-fr,"Town"@de,"Ciudad"@es,"镇"@zh .
-place:Village rdfs:label "Village"@en-gb,"Village"@fr-fr,"Village"@de,"Pueblo"@es,"村"@zh .
-place:Lake rdfs:label "Lake"@en-gb,"Lake"@fr-fr,"Lake"@de,"Lago"@es,"湖"@zh .
-place:River rdfs:label "River"@en-gb,"River"@fr-fr,"River"@de,"Río"@es,"河"@zh .
-place:Sea rdfs:label "Sea"@en-gb,"Mer"@fr-fr,"Sea"@de,"Mar"@es,"海"@zh .
-place:Ocean rdfs:label "Ocean"@en-gb,"Ocean"@fr-fr,"Ocean"@de,"Mar"@es,"海洋"@zh .
-place:Mountain rdfs:label "Mountain"@en-gb,"Mountain"@fr-fr,"Mountain"@de,"Montaña"@es,"山"@zh .
-place:Hill rdfs:label "Hill"@en-gb,"Hill"@fr-fr,"Hill"@de,"Hill"@es,"希尔"@zh .
-place:Desert rdfs:label "Desert"@en-gb,"Desert"@fr-fr,"Desert"@de,"Desierto"@es,"沙漠"@zh .
-place:County rdfs:label "County"@en-gb,"Comté"@fr-fr,"County"@de,"Condado"@es,"县"@zh .
-place:State rdfs:label "State"@en-gb,"État"@fr-fr,"Staat"@de,"Estado"@es,"国家"@zh .
-place:Hamlet rdfs:label "Hamlet"@en-gb,"Hamlet"@fr-fr,"Weiler"@de,"Aldea"@es,"村庄"@zh .
-place:Settlement rdfs:label "Settlement"@en-gb,"Règlement"@fr-fr,"Siedlung"@de,"Liquidación"@es,"解决"@zh .
-place:Reservoir rdfs:label "Reservoir"@en-gb,"Réservoir"@fr-fr,"Reservoir"@de,"Depósito"@es,"水库"@zh .
-place:Beach rdfs:label "Beach"@en-gb,"Beach"@fr-fr,"Beach"@de,"Playa"@es,"海滩"@zh .
-place:Road rdfs:label "Road"@en-gb,"Road"@fr-fr,"Road"@de,"Por carretera"@es,"路"@zh .
-place:Path rdfs:label "Path"@en-gb,"Path"@fr-fr,"Path"@de,"Ruta"@es,"路径"@zh .
-place:Bay rdfs:label "Bay"@en-gb,"Bay"@fr-fr,"Bay"@de,"Bahía"@es,"湾"@zh .
-place:Estuary rdfs:label "Estuary"@en-gb,"Estuaire"@fr-fr,"Mündung"@de,"Estuario"@es,"河口"@zh .
-place:Valley rdfs:label "Valley"@en-gb,"Vallée"@fr-fr,"Valley"@de,"Valle"@es,"谷"@zh .
-place:Plain rdfs:label "Plain"@en-gb,"Plain"@fr-fr,"Plain"@de,"Llanura"@es,"平原"@zh .
-place:Cliff rdfs:label "Cliff"@en-gb,"Cliff"@fr-fr,"Cliff"@de,"Acantilado"@es,"悬崖"@zh .
-place:Ridge rdfs:label "Ridge"@en-gb,"Ridge"@fr-fr,"Ridge"@de,"Ridge"@es,"脊"@zh .
-place:Plateau rdfs:label "Plateau"@en-gb,"Plateau"@fr-fr,"Plateau"@de,"Meseta"@es,"高原"@zh .
-place:Isthmus rdfs:label "Isthmus"@en-gb,"Isthme"@fr-fr,"Isthmus"@de,"Istmo"@es,"地峡"@zh .
-place:Peninsula rdfs:label "Peninsula"@en-gb,"Péninsule"@fr-fr,"Halbinsel"@de,"Península"@es,"半岛"@zh .
-place:Glacier rdfs:label "Glacier"@en-gb,"Glacier"@fr-fr,"Gletscher"@de,"Glaciar"@es,"冰川"@zh .
-place:Strait rdfs:label "Strait"@en-gb,"Détroit"@fr-fr,"Meerenge"@de,"Estrecho"@es,"海峡"@zh .
-place:Cape rdfs:label "Cape"@en-gb,"Cap"@fr-fr,"Cape"@de,"Cabo"@es,"披肩"@zh .
-place:Watershed rdfs:label "Watershed"@en-gb,"Des bassins versants"@fr-fr,"Wasserscheide"@de,"Cuencas"@es,"流域"@zh .
-place:Volcano rdfs:label "Volcano"@en-gb,"Volcan"@fr-fr,"Vulkan"@de,"Volcán"@es,"火山"@zh .
-place:Gulf rdfs:label "Gulf"@en-gb,"Golfe"@fr-fr,"Gulf"@de,"Golfo"@es,"海湾"@zh .
-place:Township rdfs:label "Township"@en-gb,"Canton"@fr-fr,"Township"@de,"Municipio"@es,"乡"@zh .
-place:Borough rdfs:label "Borough"@en-gb,"Arrondissement"@fr-fr,"Bezirk"@de,"Municipio"@es,"伯勒"@zh .
-place:District rdfs:label "District"@en-gb,"District"@fr-fr,"Bezirk"@de,"Distrito"@es,"区"@zh .
-place:Parish rdfs:label "Parish"@en-gb,"Paroisse"@fr-fr,"Gemeinde"@de,"Parroquia"@es,"教区"@zh .
-place:Municipality rdfs:label "Municipality"@en-gb,"Municipalité"@fr-fr,"Gemeinde"@de,"Municipio"@es,"市"@zh .
-place:Province rdfs:label "Province"@en-gb,"Province"@fr-fr,"Provinz"@de,"Provincia"@es,"省"@zh .
-place:in rdfs:label "in"@en-gb,"dans"@fr-fr,"in"@de,"en"@es,"在"@zh .
-place:overlaps rdfs:label "overlaps"@en-gb,"chevauchements"@fr-fr,"Überschneidungen"@de,"solapamientos"@es,"重叠"@zh .
+place:Plate rdfs:label "Plate"@en,"Plate"@fr-fr,"Tafel"@de,"Placa"@es,"板"@zh .
+place:LandMass rdfs:label "Landmass"@en,"La masse continentale"@fr-fr,"Landmasse"@de,"Masa de tierra"@es,"陆地"@zh .
+place:Island rdfs:label "Island"@en,"Island"@fr-fr,"Island"@de,"Isla"@es,"岛"@zh .
+place:Continent rdfs:label "Continent"@en,"Continent"@fr-fr,"Kontinent"@de,"Continente"@es,"大陆"@zh .
+place:Country rdfs:label "Country"@en,"Pays"@fr-fr,"Land"@de,"País"@es,"国家"@zh .
+place:Region rdfs:label "Region"@en,"Région"@fr-fr,"Region"@de,"Región"@es,"区"@zh .
+place:ArbitraryRegion rdfs:label "Arbitrary Region"@en,"Région Arbitraire"@fr-fr,"Willkürliche Region"@de,"Arbitraria Región"@es,"任意区域"@zh .
+place:City rdfs:label "City"@en,"City"@fr-fr,"City"@de,"Ciudad"@es,"市"@zh .
+place:Town rdfs:label "Town"@en,"Ville"@fr-fr,"Town"@de,"Ciudad"@es,"镇"@zh .
+place:Village rdfs:label "Village"@en,"Village"@fr-fr,"Village"@de,"Pueblo"@es,"村"@zh .
+place:Lake rdfs:label "Lake"@en,"Lake"@fr-fr,"Lake"@de,"Lago"@es,"湖"@zh .
+place:River rdfs:label "River"@en,"River"@fr-fr,"River"@de,"Río"@es,"河"@zh .
+place:Sea rdfs:label "Sea"@en,"Mer"@fr-fr,"Sea"@de,"Mar"@es,"海"@zh .
+place:Ocean rdfs:label "Ocean"@en,"Ocean"@fr-fr,"Ocean"@de,"Mar"@es,"海洋"@zh .
+place:Mountain rdfs:label "Mountain"@en,"Mountain"@fr-fr,"Mountain"@de,"Montaña"@es,"山"@zh .
+place:Hill rdfs:label "Hill"@en,"Hill"@fr-fr,"Hill"@de,"Hill"@es,"希尔"@zh .
+place:Desert rdfs:label "Desert"@en,"Desert"@fr-fr,"Desert"@de,"Desierto"@es,"沙漠"@zh .
+place:County rdfs:label "County"@en,"Comté"@fr-fr,"County"@de,"Condado"@es,"县"@zh .
+place:State rdfs:label "State"@en,"État"@fr-fr,"Staat"@de,"Estado"@es,"国家"@zh .
+place:Hamlet rdfs:label "Hamlet"@en,"Hamlet"@fr-fr,"Weiler"@de,"Aldea"@es,"村庄"@zh .
+place:Settlement rdfs:label "Settlement"@en,"Règlement"@fr-fr,"Siedlung"@de,"Liquidación"@es,"解决"@zh .
+place:Reservoir rdfs:label "Reservoir"@en,"Réservoir"@fr-fr,"Reservoir"@de,"Depósito"@es,"水库"@zh .
+place:Beach rdfs:label "Beach"@en,"Beach"@fr-fr,"Beach"@de,"Playa"@es,"海滩"@zh .
+place:Road rdfs:label "Road"@en,"Road"@fr-fr,"Road"@de,"Por carretera"@es,"路"@zh .
+place:Path rdfs:label "Path"@en,"Path"@fr-fr,"Path"@de,"Ruta"@es,"路径"@zh .
+place:Bay rdfs:label "Bay"@en,"Bay"@fr-fr,"Bay"@de,"Bahía"@es,"湾"@zh .
+place:Estuary rdfs:label "Estuary"@en,"Estuaire"@fr-fr,"Mündung"@de,"Estuario"@es,"河口"@zh .
+place:Valley rdfs:label "Valley"@en,"Vallée"@fr-fr,"Valley"@de,"Valle"@es,"谷"@zh .
+place:Plain rdfs:label "Plain"@en,"Plain"@fr-fr,"Plain"@de,"Llanura"@es,"平原"@zh .
+place:Cliff rdfs:label "Cliff"@en,"Cliff"@fr-fr,"Cliff"@de,"Acantilado"@es,"悬崖"@zh .
+place:Ridge rdfs:label "Ridge"@en,"Ridge"@fr-fr,"Ridge"@de,"Ridge"@es,"脊"@zh .
+place:Plateau rdfs:label "Plateau"@en,"Plateau"@fr-fr,"Plateau"@de,"Meseta"@es,"高原"@zh .
+place:Isthmus rdfs:label "Isthmus"@en,"Isthme"@fr-fr,"Isthmus"@de,"Istmo"@es,"地峡"@zh .
+place:Peninsula rdfs:label "Peninsula"@en,"Péninsule"@fr-fr,"Halbinsel"@de,"Península"@es,"半岛"@zh .
+place:Glacier rdfs:label "Glacier"@en,"Glacier"@fr-fr,"Gletscher"@de,"Glaciar"@es,"冰川"@zh .
+place:Strait rdfs:label "Strait"@en,"Détroit"@fr-fr,"Meerenge"@de,"Estrecho"@es,"海峡"@zh .
+place:Cape rdfs:label "Cape"@en,"Cap"@fr-fr,"Cape"@de,"Cabo"@es,"披肩"@zh .
+place:Watershed rdfs:label "Watershed"@en,"Des bassins versants"@fr-fr,"Wasserscheide"@de,"Cuencas"@es,"流域"@zh .
+place:Volcano rdfs:label "Volcano"@en,"Volcan"@fr-fr,"Vulkan"@de,"Volcán"@es,"火山"@zh .
+place:Gulf rdfs:label "Gulf"@en,"Golfe"@fr-fr,"Gulf"@de,"Golfo"@es,"海湾"@zh .
+place:Township rdfs:label "Township"@en,"Canton"@fr-fr,"Township"@de,"Municipio"@es,"乡"@zh .
+place:Borough rdfs:label "Borough"@en,"Arrondissement"@fr-fr,"Bezirk"@de,"Municipio"@es,"伯勒"@zh .
+place:District rdfs:label "District"@en,"District"@fr-fr,"Bezirk"@de,"Distrito"@es,"区"@zh .
+place:Parish rdfs:label "Parish"@en,"Paroisse"@fr-fr,"Gemeinde"@de,"Parroquia"@es,"教区"@zh .
+place:Municipality rdfs:label "Municipality"@en,"Municipalité"@fr-fr,"Gemeinde"@de,"Municipio"@es,"市"@zh .
+place:Province rdfs:label "Province"@en,"Province"@fr-fr,"Provinz"@de,"Provincia"@es,"省"@zh .
+place:in rdfs:label "in"@en,"dans"@fr-fr,"in"@de,"en"@es,"在"@zh .
+place:overlaps rdfs:label "overlaps"@en,"chevauchements"@fr-fr,"Überschneidungen"@de,"solapamientos"@es,"重叠"@zh .

--- a/schema.rdf.xml
+++ b/schema.rdf.xml
@@ -14,10 +14,6 @@
    xmlns:vann="http://purl.org/vocab/vann/"
    xmlns:vs="http://www.w3.org/2003/06/sw-vocab-status/ns#"
    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
-  <cc:Work rdf:about="file:///Users/rs/Platform%20Consulting/BBC/Places-Ontology/schema.rdf.ttl">
-    <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/Text"/>
-    <cc:license rdf:resource="http://creativecommons.org/licenses/by/1.0/"/>
-  </cc:Work>
   <cc:Licence rdf:about="http://creativecommons.org/licenses/by/1.0/">
     <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
     <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
@@ -29,8 +25,11 @@
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2010-11-27</dcterms:created>
     <dcterms:description xml:lang="en">The Places Ontology is a simple lightweight ontology for describing places of geographic interest.</dcterms:description>
     <dcterms:title xml:lang="en">The Places Ontology</dcterms:title>
+    <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/Text"/>
     <vann:preferredNamespacePrefix>place</vann:preferredNamespacePrefix>
-    <vann:preferredNamespaceUri rdf:resource="http://purl.org/ontology/places#"/>
+    <vann:preferredNamespaceUri>http://purl.org/ontology/places#</vann:preferredNamespaceUri>
+    <cc:license rdf:resource="http://creativecommons.org/licenses/by/1.0/"/>
+    <rdf:type rdf:resource="http://web.resource.org/cc/Work"/>
     <rdfs:comment xml:lang="en">The Places Ontology is a simple lightweight ontology for describing places of geographic interest.</rdfs:comment>
     <foaf:maker rdf:resource="http://purl.org/ontology/places/#michael"/>
     <foaf:maker rdf:resource="http://purl.org/ontology/places/#rob"/>
@@ -40,7 +39,7 @@
     <rdfs:comment>An area that is useful to illustrate a particular point but does not have a recognised political or cultural identity.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="es">Arbitraria Región</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Arbitrary Region</rdfs:label>
+    <rdfs:label xml:lang="en">Arbitrary Region</rdfs:label>
     <rdfs:label>ArbitraryRegion</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Région Arbitraire</rdfs:label>
     <rdfs:label xml:lang="de">Willkürliche Region</rdfs:label>
@@ -53,7 +52,7 @@
     <rdfs:label xml:lang="es">Bahía</rdfs:label>
     <rdfs:label>Bay</rdfs:label>
     <rdfs:label xml:lang="de">Bay</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Bay</rdfs:label>
+    <rdfs:label xml:lang="en">Bay</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Bay</rdfs:label>
     <rdfs:label xml:lang="zh">湾</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -63,7 +62,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Beach</rdfs:label>
     <rdfs:label xml:lang="de">Beach</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Beach</rdfs:label>
+    <rdfs:label xml:lang="en">Beach</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Beach</rdfs:label>
     <rdfs:label xml:lang="es">Playa</rdfs:label>
     <rdfs:label xml:lang="zh">海滩</rdfs:label>
@@ -75,7 +74,7 @@
     <rdfs:label xml:lang="fr-fr">Arrondissement</rdfs:label>
     <rdfs:label xml:lang="de">Bezirk</rdfs:label>
     <rdfs:label>Borough</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Borough</rdfs:label>
+    <rdfs:label xml:lang="en">Borough</rdfs:label>
     <rdfs:label xml:lang="es">Municipio</rdfs:label>
     <rdfs:label xml:lang="zh">伯勒</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -94,7 +93,7 @@
     <rdfs:label xml:lang="fr-fr">Cap</rdfs:label>
     <rdfs:label>Cape</rdfs:label>
     <rdfs:label xml:lang="de">Cape</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Cape</rdfs:label>
+    <rdfs:label xml:lang="en">Cape</rdfs:label>
     <rdfs:label xml:lang="zh">披肩</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:Class>
@@ -103,7 +102,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>City</rdfs:label>
     <rdfs:label xml:lang="de">City</rdfs:label>
-    <rdfs:label xml:lang="en-gb">City</rdfs:label>
+    <rdfs:label xml:lang="en">City</rdfs:label>
     <rdfs:label xml:lang="fr-fr">City</rdfs:label>
     <rdfs:label xml:lang="es">Ciudad</rdfs:label>
     <rdfs:label xml:lang="zh">市</rdfs:label>
@@ -117,7 +116,7 @@
     <rdfs:label xml:lang="es">Acantilado</rdfs:label>
     <rdfs:label>Cliff</rdfs:label>
     <rdfs:label xml:lang="de">Cliff</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Cliff</rdfs:label>
+    <rdfs:label xml:lang="en">Cliff</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Cliff</rdfs:label>
     <rdfs:label xml:lang="zh">悬崖</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -126,7 +125,7 @@
     <rdfs:comment>A large landmass recognised by convention as a continent.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Continent</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Continent</rdfs:label>
+    <rdfs:label xml:lang="en">Continent</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Continent</rdfs:label>
     <rdfs:label xml:lang="es">Continente</rdfs:label>
     <rdfs:label xml:lang="de">Kontinent</rdfs:label>
@@ -140,7 +139,7 @@
     <rdfs:comment>A region considered to be the territory of a recognised political state.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Country</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Country</rdfs:label>
+    <rdfs:label xml:lang="en">Country</rdfs:label>
     <rdfs:label xml:lang="de">Land</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Pays</rdfs:label>
     <rdfs:label xml:lang="es">País</rdfs:label>
@@ -156,7 +155,7 @@
     <rdfs:label xml:lang="es">Condado</rdfs:label>
     <rdfs:label>County</rdfs:label>
     <rdfs:label xml:lang="de">County</rdfs:label>
-    <rdfs:label xml:lang="en-gb">County</rdfs:label>
+    <rdfs:label xml:lang="en">County</rdfs:label>
     <rdfs:label xml:lang="zh">县</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/County"/>
     <vs:term_status>testing</vs:term_status>
@@ -166,7 +165,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Desert</rdfs:label>
     <rdfs:label xml:lang="de">Desert</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Desert</rdfs:label>
+    <rdfs:label xml:lang="en">Desert</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Desert</rdfs:label>
     <rdfs:label xml:lang="es">Desierto</rdfs:label>
     <rdfs:label xml:lang="zh">沙漠</rdfs:label>
@@ -178,7 +177,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="de">Bezirk</rdfs:label>
     <rdfs:label>District</rdfs:label>
-    <rdfs:label xml:lang="en-gb">District</rdfs:label>
+    <rdfs:label xml:lang="en">District</rdfs:label>
     <rdfs:label xml:lang="fr-fr">District</rdfs:label>
     <rdfs:label xml:lang="es">Distrito</rdfs:label>
     <rdfs:label xml:lang="zh">区</rdfs:label>
@@ -190,7 +189,7 @@
     <rdfs:label xml:lang="fr-fr">Estuaire</rdfs:label>
     <rdfs:label xml:lang="es">Estuario</rdfs:label>
     <rdfs:label>Estuary</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Estuary</rdfs:label>
+    <rdfs:label xml:lang="en">Estuary</rdfs:label>
     <rdfs:label xml:lang="de">Mündung</rdfs:label>
     <rdfs:label xml:lang="zh">河口</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -200,7 +199,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="es">Glaciar</rdfs:label>
     <rdfs:label>Glacier</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Glacier</rdfs:label>
+    <rdfs:label xml:lang="en">Glacier</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Glacier</rdfs:label>
     <rdfs:label xml:lang="de">Gletscher</rdfs:label>
     <rdfs:label xml:lang="zh">冰川</rdfs:label>
@@ -213,7 +212,7 @@
     <rdfs:label xml:lang="es">Golfo</rdfs:label>
     <rdfs:label>Gulf</rdfs:label>
     <rdfs:label xml:lang="de">Gulf</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Gulf</rdfs:label>
+    <rdfs:label xml:lang="en">Gulf</rdfs:label>
     <rdfs:label xml:lang="zh">海湾</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:Class>
@@ -222,7 +221,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="es">Aldea</rdfs:label>
     <rdfs:label>Hamlet</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Hamlet</rdfs:label>
+    <rdfs:label xml:lang="en">Hamlet</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Hamlet</rdfs:label>
     <rdfs:label xml:lang="de">Weiler</rdfs:label>
     <rdfs:label xml:lang="zh">村庄</rdfs:label>
@@ -233,7 +232,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Hill</rdfs:label>
     <rdfs:label xml:lang="de">Hill</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Hill</rdfs:label>
+    <rdfs:label xml:lang="en">Hill</rdfs:label>
     <rdfs:label xml:lang="es">Hill</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Hill</rdfs:label>
     <rdfs:label xml:lang="zh">希尔</rdfs:label>
@@ -246,7 +245,7 @@
     <rdfs:label xml:lang="es">Isla</rdfs:label>
     <rdfs:label>Island</rdfs:label>
     <rdfs:label xml:lang="de">Island</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Island</rdfs:label>
+    <rdfs:label xml:lang="en">Island</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Island</rdfs:label>
     <rdfs:label xml:lang="zh">岛</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Island"/>
@@ -258,7 +257,7 @@
     <rdfs:label xml:lang="fr-fr">Isthme</rdfs:label>
     <rdfs:label>Isthmus</rdfs:label>
     <rdfs:label xml:lang="de">Isthmus</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Isthmus</rdfs:label>
+    <rdfs:label xml:lang="en">Isthmus</rdfs:label>
     <rdfs:label xml:lang="es">Istmo</rdfs:label>
     <rdfs:label xml:lang="zh">地峡</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -269,7 +268,7 @@
     <rdfs:label xml:lang="es">Lago</rdfs:label>
     <rdfs:label>Lake</rdfs:label>
     <rdfs:label xml:lang="de">Lake</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Lake</rdfs:label>
+    <rdfs:label xml:lang="en">Lake</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Lake</rdfs:label>
     <rdfs:label xml:lang="zh">湖</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Lake"/>
@@ -281,7 +280,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="fr-fr">La masse continentale</rdfs:label>
     <rdfs:label>LandMass</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Landmass</rdfs:label>
+    <rdfs:label xml:lang="en">Landmass</rdfs:label>
     <rdfs:label xml:lang="de">Landmasse</rdfs:label>
     <rdfs:label xml:lang="es">Masa de tierra</rdfs:label>
     <rdfs:label xml:lang="zh">陆地</rdfs:label>
@@ -294,7 +293,7 @@
     <rdfs:label xml:lang="es">Montaña</rdfs:label>
     <rdfs:label>Mountain</rdfs:label>
     <rdfs:label xml:lang="de">Mountain</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Mountain</rdfs:label>
+    <rdfs:label xml:lang="en">Mountain</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Mountain</rdfs:label>
     <rdfs:label xml:lang="zh">山</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Mountain"/>
@@ -306,7 +305,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="de">Gemeinde</rdfs:label>
     <rdfs:label>Municipality</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Municipality</rdfs:label>
+    <rdfs:label xml:lang="en">Municipality</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Municipalité</rdfs:label>
     <rdfs:label xml:lang="es">Municipio</rdfs:label>
     <rdfs:label xml:lang="zh">市</rdfs:label>
@@ -318,7 +317,7 @@
     <rdfs:label xml:lang="es">Mar</rdfs:label>
     <rdfs:label>Ocean</rdfs:label>
     <rdfs:label xml:lang="de">Ocean</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Ocean</rdfs:label>
+    <rdfs:label xml:lang="en">Ocean</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Ocean</rdfs:label>
     <rdfs:label xml:lang="zh">海洋</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Ocean"/>
@@ -329,7 +328,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="de">Gemeinde</rdfs:label>
     <rdfs:label>Parish</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Parish</rdfs:label>
+    <rdfs:label xml:lang="en">Parish</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Paroisse</rdfs:label>
     <rdfs:label xml:lang="es">Parroquia</rdfs:label>
     <rdfs:label xml:lang="zh">教区</rdfs:label>
@@ -340,7 +339,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Path</rdfs:label>
     <rdfs:label xml:lang="de">Path</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Path</rdfs:label>
+    <rdfs:label xml:lang="en">Path</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Path</rdfs:label>
     <rdfs:label xml:lang="es">Ruta</rdfs:label>
     <rdfs:label xml:lang="zh">路径</rdfs:label>
@@ -351,7 +350,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="de">Halbinsel</rdfs:label>
     <rdfs:label>Peninsula</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Peninsula</rdfs:label>
+    <rdfs:label xml:lang="en">Peninsula</rdfs:label>
     <rdfs:label xml:lang="es">Península</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Péninsule</rdfs:label>
     <rdfs:label xml:lang="zh">半岛</rdfs:label>
@@ -363,7 +362,7 @@
     <rdfs:label xml:lang="es">Llanura</rdfs:label>
     <rdfs:label>Plain</rdfs:label>
     <rdfs:label xml:lang="de">Plain</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Plain</rdfs:label>
+    <rdfs:label xml:lang="en">Plain</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Plain</rdfs:label>
     <rdfs:label xml:lang="zh">平原</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -373,7 +372,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="es">Placa</rdfs:label>
     <rdfs:label>Plate</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Plate</rdfs:label>
+    <rdfs:label xml:lang="en">Plate</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Plate</rdfs:label>
     <rdfs:label xml:lang="de">Tafel</rdfs:label>
     <rdfs:label xml:lang="zh">板</rdfs:label>
@@ -386,7 +385,7 @@
     <rdfs:label xml:lang="es">Meseta</rdfs:label>
     <rdfs:label>Plateau</rdfs:label>
     <rdfs:label xml:lang="de">Plateau</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Plateau</rdfs:label>
+    <rdfs:label xml:lang="en">Plateau</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Plateau</rdfs:label>
     <rdfs:label xml:lang="zh">高原</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -395,7 +394,7 @@
     <rdfs:comment>A region of governance.</rdfs:comment>
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Province</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Province</rdfs:label>
+    <rdfs:label xml:lang="en">Province</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Province</rdfs:label>
     <rdfs:label xml:lang="es">Provincia</rdfs:label>
     <rdfs:label xml:lang="de">Provinz</rdfs:label>
@@ -407,7 +406,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Region</rdfs:label>
     <rdfs:label xml:lang="de">Region</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Region</rdfs:label>
+    <rdfs:label xml:lang="en">Region</rdfs:label>
     <rdfs:label xml:lang="es">Región</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Région</rdfs:label>
     <rdfs:label xml:lang="zh">区</rdfs:label>
@@ -420,7 +419,7 @@
     <rdfs:label xml:lang="es">Depósito</rdfs:label>
     <rdfs:label>Reservoir</rdfs:label>
     <rdfs:label xml:lang="de">Reservoir</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Reservoir</rdfs:label>
+    <rdfs:label xml:lang="en">Reservoir</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Réservoir</rdfs:label>
     <rdfs:label xml:lang="zh">水库</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -430,7 +429,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>Ridge</rdfs:label>
     <rdfs:label xml:lang="de">Ridge</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Ridge</rdfs:label>
+    <rdfs:label xml:lang="en">Ridge</rdfs:label>
     <rdfs:label xml:lang="es">Ridge</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Ridge</rdfs:label>
     <rdfs:label xml:lang="zh">脊</rdfs:label>
@@ -441,7 +440,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label>River</rdfs:label>
     <rdfs:label xml:lang="de">River</rdfs:label>
-    <rdfs:label xml:lang="en-gb">River</rdfs:label>
+    <rdfs:label xml:lang="en">River</rdfs:label>
     <rdfs:label xml:lang="fr-fr">River</rdfs:label>
     <rdfs:label xml:lang="es">Río</rdfs:label>
     <rdfs:label xml:lang="zh">河</rdfs:label>
@@ -455,7 +454,7 @@
     <rdfs:label xml:lang="es">Por carretera</rdfs:label>
     <rdfs:label>Road</rdfs:label>
     <rdfs:label xml:lang="de">Road</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Road</rdfs:label>
+    <rdfs:label xml:lang="en">Road</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Road</rdfs:label>
     <rdfs:label xml:lang="zh">路</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -467,7 +466,7 @@
     <rdfs:label xml:lang="fr-fr">Mer</rdfs:label>
     <rdfs:label>Sea</rdfs:label>
     <rdfs:label xml:lang="de">Sea</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Sea</rdfs:label>
+    <rdfs:label xml:lang="en">Sea</rdfs:label>
     <rdfs:label xml:lang="zh">海</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Sea"/>
     <vs:term_status>testing</vs:term_status>
@@ -478,7 +477,7 @@
     <rdfs:label xml:lang="es">Liquidación</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Règlement</rdfs:label>
     <rdfs:label>Settlement</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Settlement</rdfs:label>
+    <rdfs:label xml:lang="en">Settlement</rdfs:label>
     <rdfs:label xml:lang="de">Siedlung</rdfs:label>
     <rdfs:label xml:lang="zh">解决</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -489,7 +488,7 @@
     <rdfs:label xml:lang="es">Estado</rdfs:label>
     <rdfs:label xml:lang="de">Staat</rdfs:label>
     <rdfs:label>State</rdfs:label>
-    <rdfs:label xml:lang="en-gb">State</rdfs:label>
+    <rdfs:label xml:lang="en">State</rdfs:label>
     <rdfs:label xml:lang="fr-fr">État</rdfs:label>
     <rdfs:label xml:lang="zh">国家</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -501,7 +500,7 @@
     <rdfs:label xml:lang="es">Estrecho</rdfs:label>
     <rdfs:label xml:lang="de">Meerenge</rdfs:label>
     <rdfs:label>Strait</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Strait</rdfs:label>
+    <rdfs:label xml:lang="en">Strait</rdfs:label>
     <rdfs:label xml:lang="zh">海峡</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:Class>
@@ -511,7 +510,7 @@
     <rdfs:label xml:lang="es">Ciudad</rdfs:label>
     <rdfs:label>Town</rdfs:label>
     <rdfs:label xml:lang="de">Town</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Town</rdfs:label>
+    <rdfs:label xml:lang="en">Town</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Ville</rdfs:label>
     <rdfs:label xml:lang="zh">镇</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Town"/>
@@ -524,7 +523,7 @@
     <rdfs:label xml:lang="es">Municipio</rdfs:label>
     <rdfs:label>Township</rdfs:label>
     <rdfs:label xml:lang="de">Township</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Township</rdfs:label>
+    <rdfs:label xml:lang="en">Township</rdfs:label>
     <rdfs:label xml:lang="zh">乡</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:Class>
@@ -534,7 +533,7 @@
     <rdfs:label xml:lang="es">Valle</rdfs:label>
     <rdfs:label>Valley</rdfs:label>
     <rdfs:label xml:lang="de">Valley</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Valley</rdfs:label>
+    <rdfs:label xml:lang="en">Valley</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Vallée</rdfs:label>
     <rdfs:label xml:lang="zh">谷</rdfs:label>
     <vs:term_status>testing</vs:term_status>
@@ -545,7 +544,7 @@
     <rdfs:label xml:lang="es">Pueblo</rdfs:label>
     <rdfs:label>Village</rdfs:label>
     <rdfs:label xml:lang="de">Village</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Village</rdfs:label>
+    <rdfs:label xml:lang="en">Village</rdfs:label>
     <rdfs:label xml:lang="fr-fr">Village</rdfs:label>
     <rdfs:label xml:lang="zh">村</rdfs:label>
     <rdfs:seeAlso rdf:resource="http://en.wikipedia.org/wiki/Village"/>
@@ -556,7 +555,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="fr-fr">Volcan</rdfs:label>
     <rdfs:label>Volcano</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Volcano</rdfs:label>
+    <rdfs:label xml:lang="en">Volcano</rdfs:label>
     <rdfs:label xml:lang="es">Volcán</rdfs:label>
     <rdfs:label xml:lang="de">Vulkan</rdfs:label>
     <rdfs:label xml:lang="zh">火山</rdfs:label>
@@ -569,7 +568,7 @@
     <rdfs:label xml:lang="fr-fr">Des bassins versants</rdfs:label>
     <rdfs:label xml:lang="de">Wasserscheide</rdfs:label>
     <rdfs:label>Watershed</rdfs:label>
-    <rdfs:label xml:lang="en-gb">Watershed</rdfs:label>
+    <rdfs:label xml:lang="en">Watershed</rdfs:label>
     <rdfs:label xml:lang="zh">流域</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:Class>
@@ -587,7 +586,7 @@
     <rdfs:label xml:lang="es">en</rdfs:label>
     <rdfs:label>in</rdfs:label>
     <rdfs:label xml:lang="de">in</rdfs:label>
-    <rdfs:label xml:lang="en-gb">in</rdfs:label>
+    <rdfs:label xml:lang="en">in</rdfs:label>
     <rdfs:label xml:lang="zh">在</rdfs:label>
     <vs:term_status>testing</vs:term_status>
   </owl:ObjectProperty>
@@ -600,7 +599,7 @@
     <rdfs:isDefinedBy rdf:resource="http://purl.org/ontology/places#"/>
     <rdfs:label xml:lang="fr-fr">chevauchements</rdfs:label>
     <rdfs:label>overlaps</rdfs:label>
-    <rdfs:label xml:lang="en-gb">overlaps</rdfs:label>
+    <rdfs:label xml:lang="en">overlaps</rdfs:label>
     <rdfs:label xml:lang="es">solapamientos</rdfs:label>
     <rdfs:label xml:lang="de">Überschneidungen</rdfs:label>
     <rdfs:label xml:lang="zh">重叠</rdfs:label>


### PR DESCRIPTION
I needed to alter the index.php to work with purl.org/ontology URIs.
- Also I fixed vann:namespaceUri which should be a literal
- I made the cc:Work resource an absolute URI, the version in your repo has a local file path
- I changed all the en-gb languages to en which is more general. My preference is to at least have the most general form and then use the regional qualifier to specify a more localised version
